### PR TITLE
hon: added swig/examples/simple

### DIFF
--- a/swig/examples/simple/Makefile
+++ b/swig/examples/simple/Makefile
@@ -1,0 +1,83 @@
+# built swig with
+# ./configure --prefix=/opt --with-go=/opt/bin/go --with-ruby=/opt/bin/ruby --with-python3=/opt/bin/python3.5
+
+.PHONY: clean rbnewmath pynewmath jsnewmath jvmnewmath
+
+#SHELL := /bin/tcsh -f
+SHELL := /bin/bash
+
+SRC := $(shell ls -1 *.c)
+OBJC := $(patsubst %.c,%.o,$(SRC))
+
+SRCC := $(shell ls -1 *.cc)
+OBJCC := $(patsubst %.cc,%.o,$(SRCC))
+
+CLEANME := tags TAGS $(OBJC) $(OBJCC) *_wrap.c *cache* lib*/*.so *~
+
+#GOINC := -I/opt/include/go
+RBINC := -I/opt/include/ruby-2.3.0 -I/opt/include/ruby-2.3.0/x86_64-linux
+PYINC := -I/opt/include/python3.5m
+JVMINC := -I/opt/jvm/jdk/include -I/opt/jvm/jdk/include/linux
+JSINC := -I/opt/include/node
+
+FLAGS := -Wall -fPIC 
+CFLAGS := -std=c99 $(FLAGS)
+#CFLAGS := -std=c11 $(FLAGS)
+CXXFLAGS := -std=c++11 $(FLAGS)
+
+LDFLAGS := -L/opt/lib -L/opt/lib/ruby -L/opt/lib/python3 -L/opt/jvm/jdk/lib 
+LD := gcc -rdynamic $(LDFLAGS)
+LD++ := g++ -rdynamic $(LDFLAGS)
+
+RM := rm -rf
+
+newmath: rbnewmath pynewmath 
+	@echo made newmath
+
+rbnewmath: clean
+# generate fact_wrap.c
+	swig -ruby fact.h
+	gcc -c $(CFLAGS) $(RBINC) fact.c fact_wrap.c
+# note lower case ruby extension filename for require statement; see swig notes at test target below ...
+	$(LD++) -o libruby/newmath.so -shared $(CFLAGS) $(RBINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PRBINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libruby/newmath.so -shared $(CXXFLAGS) $(RBINC) fact.o fact_wrap.o 
+
+pynewmath: clean
+# generate fact_wrap.c
+	swig -python fact.h
+	gcc -c $(CFLAGS) $(PYINC) fact.c fact_wrap.c
+# note pythom import expects underscore prefix to module shared-lib name:
+	$(LD++) -o libpython/_newmath.so -shared $(CFLAGS) $(PYINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PYINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libpython/_newmath.so -shared $(CXXFLAGS) $(PYINC) fact.o fact_wrap.o 
+
+clean:
+	-@mkdir libpython libruby
+# according to the man page: rm -f, --force -- ignore nonexistent files and arguments, never prompt
+# yet this rm complains, so pre-touch  ...
+	-@touch $(CLEANME)
+	-$(RM) $(CLEANME)
+
+# from the swig ruby docs:
+# Ruby module names must be capitalized, but the convention for Ruby feature names is to use lowercase
+# names. To stay consistent with this practice, you should always specify a lowercase module name with
+# SWIG's %module directive. SWIG will automatically correct the resulting Ruby module name for your
+# extension. So for example, a SWIG interface file that begins with:
+# %module example
+# will result in an extension module using the feature name "example" and Ruby module name "Example".
+test:
+	env RUBYLIB=./libruby ruby -e "print $$:"
+	env RUBYLIB=./libruby ruby -e "require 'newmath' ; f = Newmath.fact(7)"
+	env PYTHONPATH=./libpython python3 -c "import newmath ; f = newmath.fact(7)"
+
+$(OBJC): $(SRC)
+
+$(OBJCC): $(SRCC)
+
+%.o : %.c
+	gcc -c $(CFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+
+%.o : %.cc
+	g++ -c $(CXXFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+

--- a/swig/examples/simple/Makefile.linux
+++ b/swig/examples/simple/Makefile.linux
@@ -1,0 +1,83 @@
+# built swig with
+# ./configure --prefix=/opt --with-go=/opt/bin/go --with-ruby=/opt/bin/ruby --with-python3=/opt/bin/python3.5
+
+.PHONY: clean rbnewmath pynewmath jsnewmath jvmnewmath
+
+#SHELL := /bin/tcsh -f
+SHELL := /bin/bash
+
+SRC := $(shell ls -1 *.c)
+OBJC := $(patsubst %.c,%.o,$(SRC))
+
+SRCC := $(shell ls -1 *.cc)
+OBJCC := $(patsubst %.cc,%.o,$(SRCC))
+
+CLEANME := tags TAGS $(OBJC) $(OBJCC) *_wrap.c *cache* lib*/*.so *~
+
+#GOINC := -I/opt/include/go
+RBINC := -I/opt/include/ruby-2.3.0 -I/opt/include/ruby-2.3.0/x86_64-linux
+PYINC := -I/opt/include/python3.5m
+JVMINC := -I/opt/jvm/jdk/include -I/opt/jvm/jdk/include/linux
+JSINC := -I/opt/include/node
+
+FLAGS := -Wall -fPIC 
+CFLAGS := -std=c99 $(FLAGS)
+#CFLAGS := -std=c11 $(FLAGS)
+CXXFLAGS := -std=c++11 $(FLAGS)
+
+LDFLAGS := -L/opt/lib -L/opt/lib/ruby -L/opt/lib/python3 -L/opt/jvm/jdk/lib 
+LD := gcc -rdynamic $(LDFLAGS)
+LD++ := g++ -rdynamic $(LDFLAGS)
+
+RM := rm -rf
+
+newmath: rbnewmath pynewmath 
+	@echo made newmath
+
+rbnewmath: clean
+# generate fact_wrap.c
+	swig -ruby fact.h
+	gcc -c $(CFLAGS) $(RBINC) fact.c fact_wrap.c
+# note lower case ruby extension filename for require statement; see swig notes at test target below ...
+	$(LD++) -o libruby/newmath.so -shared $(CFLAGS) $(RBINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PRBINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libruby/newmath.so -shared $(CXXFLAGS) $(RBINC) fact.o fact_wrap.o 
+
+pynewmath: clean
+# generate fact_wrap.c
+	swig -python fact.h
+	gcc -c $(CFLAGS) $(PYINC) fact.c fact_wrap.c
+# note pythom import expects underscore prefix to module shared-lib name:
+	$(LD++) -o libpython/_newmath.so -shared $(CFLAGS) $(PYINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PYINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libpython/_newmath.so -shared $(CXXFLAGS) $(PYINC) fact.o fact_wrap.o 
+
+clean:
+	-@mkdir libpython libruby
+# according to the man page: rm -f, --force -- ignore nonexistent files and arguments, never prompt
+# yet this rm complains, so pre-touch  ...
+	-@touch $(CLEANME)
+	-$(RM) $(CLEANME)
+
+# from the swig ruby docs:
+# Ruby module names must be capitalized, but the convention for Ruby feature names is to use lowercase
+# names. To stay consistent with this practice, you should always specify a lowercase module name with
+# SWIG's %module directive. SWIG will automatically correct the resulting Ruby module name for your
+# extension. So for example, a SWIG interface file that begins with:
+# %module example
+# will result in an extension module using the feature name "example" and Ruby module name "Example".
+test:
+	env RUBYLIB=./libruby ruby -e "print $$:"
+	env RUBYLIB=./libruby ruby -e "require 'newmath' ; f = Newmath.fact(7)"
+	env PYTHONPATH=./libpython python3 -c "import newmath ; f = newmath.fact(7)"
+
+$(OBJC): $(SRC)
+
+$(OBJCC): $(SRCC)
+
+%.o : %.c
+	gcc -c $(CFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+
+%.o : %.cc
+	g++ -c $(CXXFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+

--- a/swig/examples/simple/Makefile.mac
+++ b/swig/examples/simple/Makefile.mac
@@ -1,0 +1,86 @@
+# built swig with
+# ./configure --prefix=/opt --with-go=/opt/bin/go --with-ruby=/opt/bin/ruby --with-python3=/opt/bin/python3.5
+
+.PHONY: clean newmath rbnewmath pynewmath jsnewmath jvmnewmath
+
+#PREFIX := /opt
+PREFIX := /Users/davidhon/opt
+
+#SHELL := /bin/tcsh -f
+SHELL := /bin/bash
+
+SRC := $(shell ls -1 *.c)
+OBJC := $(patsubst %.c,%.o,$(SRC))
+
+SRCC := $(shell ls -1 *.cc)
+OBJCC := $(patsubst %.cc,%.o,$(SRCC))
+
+CLEANME := tags TAGS $(OBJC) $(OBJCC) *_wrap.c *cache* lib*/*.so *~
+
+#GOINC := -I$(PREFIX)/include/go
+RBINC := -I$(PREFIX)/include/ruby-2.3.0 -I$(PREFIX)/include/ruby-2.3.0/x86_64-darwin14
+PYINC := -I$(PREFIX)/include/python3.5m
+JVMINC := -I$(PREFIX)/jvm/jdk/include -I$(PREFIX)/jvm/jdk/include/x86_64-darwin14
+JSINC := -I$(PREFIX)/include/node
+
+FLAGS := -Wall -fPIC 
+CFLAGS := -std=c99 $(FLAGS)
+#CFLAGS := -std=c11 $(FLAGS)
+CXXFLAGS := -std=c++11 $(FLAGS)
+
+LDFLAGS := -L$(PREFIX)/lib -L$(PREFIX)/lib/ruby -L$(PREFIX)/lib/python3 -L$(PREFIX)/jvm/jdk/lib 
+LD := gcc -rdynamic $(LDFLAGS)
+LD++ := g++ -rdynamic $(LDFLAGS)
+
+RM := rm -rf
+
+newmath: rbnewmath pynewmath 
+	@echo made newmath
+
+rbnewmath: clean
+# generate fact_wrap.c
+	~/opt/bin/swig -ruby fact.h
+	gcc -c $(CFLAGS) $(RBINC) fact.c fact_wrap.c
+# note lower case ruby extension filename for require statement; see swig notes at test target below ...
+	$(LD++) -o libruby/newmath.so -shared $(CFLAGS) $(RBINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PRBINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libruby/newmath.so -shared $(CXXFLAGS) $(RBINC) fact.o fact_wrap.o 
+
+pynewmath: clean
+# generate fact_wrap.c
+	~/opt/bin/swig -python fact.h
+	gcc -c $(CFLAGS) $(PYINC) fact.c fact_wrap.c
+# note pythom import expects underscore prefix to module shared-lib name:
+	$(LD++) -o libpython/_newmath.so -shared $(CFLAGS) $(PYINC) fact.o fact_wrap.o 
+#	g++ -c $(CXXFLAGS) $(PYINC) fact.cc fact_wrap.cxx
+#	$(LD++) -o libpython/_newmath.so -shared $(CXXFLAGS) $(PYINC) fact.o fact_wrap.o 
+
+clean:
+	-@mkdir libpython libruby
+# according to the man page: rm -f, --force -- ignore nonexistent files and arguments, never prompt
+# yet this rm complains, so pre-touch  ...
+	-@touch $(CLEANME)
+	-$(RM) $(CLEANME)
+
+# from the swig ruby docs:
+# Ruby module names must be capitalized, but the convention for Ruby feature names is to use lowercase
+# names. To stay consistent with this practice, you should always specify a lowercase module name with
+# SWIG's %module directive. SWIG will automatically correct the resulting Ruby module name for your
+# extension. So for example, a SWIG interface file that begins with:
+# %module example
+# will result in an extension module using the feature name "example" and Ruby module name "Example".
+test:
+	env RUBYLIB=./libruby ruby -e "print $$:"
+	env RUBYLIB=./libruby ruby -e "require 'newmath' ; f = Newmath.fact(7)"
+	env PYTHONPATH=./libpython python3 -c "import newmath ; f = newmath.fact(7)"
+
+$(OBJC): $(SRC)
+
+$(OBJCC): $(SRCC)
+
+%.o : %.c
+	gcc -c $(CFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+
+%.o : %.cc
+	g++ -c $(CXXFLAGS) -o $@ $< ; touch OTAGS tags ; etags --append $< ; ctags --update $< 
+

--- a/swig/examples/simple/ReadMe.md
+++ b/swig/examples/simple/ReadMe.md
@@ -7,5 +7,8 @@ Python specifics, take a look at http://www.swig.org/Doc3.0/Ruby.html
 and http://www.swig.org/Doc3.0/Python.html.
 
 Use "make" to build target modules; and "make test" to verify.
+Edit the make macros inthe Makefile to point to the desired
+installation(s) of Ruby and Python. The initial version of the
+Makefile sets the macros to /opt/include and /opt/lib etc.
 
 Tested on Ubuntu. Needs testing on other Linuxes and MAC OS.

--- a/swig/examples/simple/ReadMe.md
+++ b/swig/examples/simple/ReadMe.md
@@ -7,8 +7,8 @@ Python specifics, take a look at http://www.swig.org/Doc3.0/Ruby.html
 and http://www.swig.org/Doc3.0/Python.html.
 
 Use "make" to build target modules; and "make test" to verify.
-Edit the make macros inthe Makefile to point to the desired
+Edit the make macros in the Makefile to point to the desired
 installation(s) of Ruby and Python. The initial version of the
-Makefile sets the macros to /opt/include and /opt/lib etc.
+Makefile sets the macros to "/opt/include" and "/opt/lib" etc.
 
 Tested on Ubuntu. Needs testing on other Linuxes and MAC OS.

--- a/swig/examples/simple/ReadMe.md
+++ b/swig/examples/simple/ReadMe.md
@@ -1,0 +1,9 @@
+This demonstrates how one can make existing C code available
+to Ruby or Python (and many other runtimes) as an external module.
+
+The Makefile comments provide some info. on swig's idiosynchracies.
+To learn more about swig, please see http://swig.org. For Ruby and
+Python specifics, take a look at http://www.swig.org/Doc3.0/Ruby.html
+and http://www.swig.org/Doc3.0/Python.html.
+
+Use "make" to build target modules; and "make test" to verify.

--- a/swig/examples/simple/ReadMe.md
+++ b/swig/examples/simple/ReadMe.md
@@ -7,3 +7,5 @@ Python specifics, take a look at http://www.swig.org/Doc3.0/Ruby.html
 and http://www.swig.org/Doc3.0/Python.html.
 
 Use "make" to build target modules; and "make test" to verify.
+
+Tested on Ubuntu. Needs testing on other Linuxes and MAC OS.

--- a/swig/examples/simple/fact.c
+++ b/swig/examples/simple/fact.c
@@ -1,0 +1,16 @@
+#include "fact.h"
+#include "limits.h"
+#include "stdio.h"
+
+long fact(long n) {
+  printf("newmath.fact> %ld\n", n);
+  // termination of recursion
+  if( n <= 1 ) return 1;
+
+  if( INT_MAX/n < n-1 ) {
+    printf("newmath.fact> overflow %ld\n", n);
+    return 1;
+  }
+  return n*fact(n-1);
+}
+

--- a/swig/examples/simple/fact.h
+++ b/swig/examples/simple/fact.h
@@ -1,0 +1,30 @@
+#if !defined(FACT_H)
+#define FACT_H
+
+// http://www.swig.org/tutorial.html section "SWIG for the truly lazy"
+// this ensure same module name for ruby require and python import, but
+// each runtime share-lib loader expects slightly different names for 
+// respective share library runtimes (see Makefile comments) ...
+
+// this is used by the swig pre-processor, rather than using *.i files:
+#ifdef SWIG
+%module newmath
+%{
+#define SWIG_FILE_WITH_INIT
+#include "fact.h"
+%}
+#endif
+
+// check for c vs. c++ compiler
+
+#if defined(__cplusplus)
+  extern long fact(long n=42);
+//  extern int factarray(long* in, long* out, int sz=3);
+//  extern int factmatrix(long** in, long** out, int x_sz=3, int y_sz=2);
+#else
+  extern long fact(long n);
+//  extern int factarray(long* in, long* out, int sz);
+//  extern int factmatrix(long** in, long** out, int x_sz, int y_sz);
+#endif
+
+#endif // FACT_H


### PR DESCRIPTION
This is just a potential starting point -- evaluate use of swig to generate iRODS "bindings"
for Go, Ruby, Python, and perhaps other runtimes. In theory the module extensions
for each language can derive from the same src and offer nearly identical module
namespace func. signatures. 
